### PR TITLE
Fix assert for structs with no decorations

### DIFF
--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -489,6 +489,10 @@ static SpvReflectResult ParseNodes(Parser* p_parser)
       }
       break;
 
+      case SpvOpTypeStruct:
+      {
+        p_node->member_count = p_node->word_count - 2;
+      } // fallthrough
       case SpvOpTypeVoid:
       case SpvOpTypeBool:
       case SpvOpTypeInt:
@@ -496,7 +500,6 @@ static SpvReflectResult ParseNodes(Parser* p_parser)
       case SpvOpTypeVector:
       case SpvOpTypeMatrix:
       case SpvOpTypeSampler:
-      case SpvOpTypeStruct:
       case SpvOpTypeOpaque:
       case SpvOpTypeFunction:
       case SpvOpTypeEvent:


### PR DESCRIPTION
Previously, if a shader didn't decorate all the members (or
specifically, the last member) with any decorations/names,
an assert would trigger in ParseTypes because the OpTypeStruct's
member_count would be 0.  This fixes that by hardcoding member count for
Struct types to word_count - 2 (based on the binary encoding of
OpTypeStruct).