### PR TITLE
Fixed push constant name

### DIFF
--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -2922,6 +2922,7 @@ static SpvReflectResult ParsePushConstantBlocks(Parser* p_parser, SpvReflectShad
     SpvReflectBlockVariable* p_push_constant = &p_module->push_constant_blocks[push_constant_index];
     p_push_constant->spirv_id = p_node->result_id;
     SpvReflectResult result = ParseDescriptorBlockVariable(p_parser, p_module, p_type, p_push_constant);
+	p_push_constant->name = p_node->name;
     if (result != SPV_REFLECT_RESULT_SUCCESS) {
       return result;
     }


### PR DESCRIPTION
Type name was used before instead of variable name